### PR TITLE
Fix issue #15: Unify validation logic in ArgumentParser

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -212,63 +212,7 @@ export class ArgumentParser {
   }
 
   static validateArgs(args: CLIArgs): boolean {
-    // Help command is always valid
-    if (args.help) {
-      return true;
-    }
-
-    // Must have either prompt or input file
-    if (!args.prompt && !args.inputFile) {
-      return false;
-    }
-
-    // Validate maxTurns if provided
-    if (args.maxTurns !== undefined && (args.maxTurns <= 0 || args.maxTurns > 100)) {
-      return false;
-    }
-
-    // Validate sessionId if provided
-    if (args.sessionId !== undefined && (typeof args.sessionId !== 'string' || args.sessionId.trim().length === 0)) {
-      return false;
-    }
-
-    // Validate settingsFile if provided
-    if (args.settingsFile !== undefined && (typeof args.settingsFile !== 'string' || args.settingsFile.trim().length === 0)) {
-      return false;
-    }
-
-    // Cannot use both continue and resume
-    if (args.continue && args.sessionId) {
-      return false;
-    }
-
-    // Validate output format if provided
-    if (args.outputFormat !== undefined && args.outputFormat !== 'json' && args.outputFormat !== 'text') {
-      return false;
-    }
-
-    // Validate output-related arguments
-    if (args.outputFile !== undefined && (typeof args.outputFile !== 'string' || args.outputFile.trim().length === 0)) {
-      return false;
-    }
-
-    if (args.outputDir !== undefined && (typeof args.outputDir !== 'string' || args.outputDir.trim().length === 0)) {
-      return false;
-    }
-
-    // No conflicting options to check for output
-
-    // Validate customSystemPrompt if provided
-    if (args.customSystemPrompt !== undefined && (typeof args.customSystemPrompt !== 'string' || args.customSystemPrompt.trim().length === 0)) {
-      return false;
-    }
-
-    // Validate systemPromptFile if provided
-    if (args.systemPromptFile !== undefined && (typeof args.systemPromptFile !== 'string' || args.systemPromptFile.trim().length === 0)) {
-      return false;
-    }
-
-    return true;
+    return this.getValidationError(args) === null;
   }
 
   static getValidationError(args: CLIArgs): string | null {


### PR DESCRIPTION
## Summary
- Refactor `validateArgs()` to use `getValidationError()` internally
- Eliminate ~50 lines of duplicate validation code between the two functions
- Maintain identical functionality while following DRY principle

## Changes Made
- Modified `ArgumentParser.validateArgs()` in `src/cli/args.ts` to simply return `this.getValidationError(args) === null`
- Removed 57 lines of duplicate validation logic
- All validation rules now exist in a single location (`getValidationError()`)

## Benefits
- **DRY principle**: Single source of truth for validation rules
- **Maintainability**: Easier to add/modify validation rules
- **Testing**: Simpler to test validation logic
- **Code quality**: Reduced code duplication by ~50 lines

## Testing
- All 381 tests pass, confirming no regressions
- Validation behavior remains identical to before
- Both unit tests and integration tests verify functionality

## Related Issue
Fixes #15

## Test Plan
- [x] Run full test suite (`npm test`) - all 381 tests pass
- [x] Verify argument parsing tests specifically - all 147 tests pass
- [x] Confirm validation logic works identically to before
- [x] Build succeeds without errors